### PR TITLE
ci: fix acceptance-test CI — bump macOS runner + avoid expired HashiCorp key

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,7 +53,7 @@ jobs:
 
   tests-macos:
     name: Run acceptance tests on macOS
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4.1.0

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,10 +45,17 @@ jobs:
       - uses: actions/setup-go@v4.1.0
         with:
           go-version: ${{env.GO_VERSION}}
+      # Pre-install Terraform so the acceptance-test framework uses it via
+      # TF_ACC_TERRAFORM_PATH instead of downloading + verifying releases
+      # against HashiCorp's expired PGP signing key (openpgp: key expired).
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - run: sudo apt-get install -y sl
       - run: |
           git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch v0.16.2
           . $HOME/.asdf/asdf.sh
+          export TF_ACC_TERRAFORM_PATH="$(which terraform)"
           make TESTARGS="-tags=apt" testacc
 
   tests-macos:
@@ -59,8 +66,15 @@ jobs:
       - uses: actions/setup-go@v4.1.0
         with:
           go-version: ${{env.GO_VERSION}}
+      # Pre-install Terraform so the acceptance-test framework uses it via
+      # TF_ACC_TERRAFORM_PATH instead of downloading + verifying releases
+      # against HashiCorp's expired PGP signing key (openpgp: key expired).
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - run: brew install sl
       - run: |
           [ -f "$HOME/.asdf/asdf.sh" ] || git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch v0.16.2
           . $HOME/.asdf/asdf.sh
+          export TF_ACC_TERRAFORM_PATH="$(which terraform)"
           make TESTARGS="-tags=brew" testacc

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y pandoc
           go install github.com/mrtazz/checkmake/cmd/checkmake@ca982aef0af387413edc4b515880bef071730dea
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.1.4
           terraform_wrapper: false
@@ -53,9 +53,10 @@ jobs:
           terraform_wrapper: false
       - run: sudo apt-get install -y sl
       - run: |
+          TF_BIN="$(which terraform)"   # capture setup-terraform binary before asdf shims can shadow PATH
           git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch v0.16.2
           . $HOME/.asdf/asdf.sh
-          export TF_ACC_TERRAFORM_PATH="$(which terraform)"
+          export TF_ACC_TERRAFORM_PATH="$TF_BIN"
           make TESTARGS="-tags=apt" testacc
 
   tests-macos:
@@ -74,7 +75,8 @@ jobs:
           terraform_wrapper: false
       - run: brew install sl
       - run: |
+          TF_BIN="$(which terraform)"   # capture setup-terraform binary before asdf shims can shadow PATH
           [ -f "$HOME/.asdf/asdf.sh" ] || git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch v0.16.2
           . $HOME/.asdf/asdf.sh
-          export TF_ACC_TERRAFORM_PATH="$(which terraform)"
+          export TF_ACC_TERRAFORM_PATH="$TF_BIN"
           make TESTARGS="-tags=brew" testacc


### PR DESCRIPTION
## Summary

Two independent CI breakages in `.github/workflows/checks.yml`, both fixed here so the acceptance-test jobs actually run and pass.

### 1. Dead macOS runner (`macos-11` → `macos-latest`)

`tests-macos` used `runs-on: macos-11`, a runner image GitHub has removed, so the job was cancelled instantly on every run (`startedAt == completedAt`), leaving PRs — including the Dependabot backlog — in `UNSTABLE`. Bumped to `macos-latest` (currently macos-15, Apple Silicon), so the job schedules and runs. Note the arch change Intel → arm64 (Homebrew at `/opt/homebrew`).

### 2. Expired HashiCorp GPG key breaking the acceptance tests

With the macOS job running again, the `internal/provider` acceptance tests failed on **both** Ubuntu and macOS:

```
cannot run Terraform provider tests: failed to find or install Terraform CLI:
unable to verify checksums signature: openpgp: key expired
```

The test framework downloads the Terraform CLI and verifies its release signature against HashiCorp's signing key, which has expired. Fixed by pre-installing Terraform via `hashicorp/setup-terraform` (which does not hit the expired-key path) and pointing the tests at it with `TF_ACC_TERRAFORM_PATH`, so they no longer download + verify releases themselves. This was a pre-existing failure — the Dependabot PRs' "green" Ubuntu status was stale CI from before the key expired.

## Test Plan

- [x] `Run acceptance tests on macOS` schedules and runs (no longer instantly cancelled) — verified on this PR, runs on arm64
- [x] `Run acceptance tests on Ubuntu` and `Run acceptance tests on macOS` pass (no more `openpgp: key expired`) — both COMPLETED/SUCCESS
- [x] `Run linters with pre-commit` remains green — SUCCESS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of acceptance and pre-commit checks by using a consistent Terraform setup.
  * Reduced test failures caused by tool download or verification issues during CI runs.
  * Updated macOS test runners to a newer hosted environment for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->